### PR TITLE
Add support for excluding URLs from CSRF protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ app.add_middleware(CSRFMiddleware, secret="__CHANGE_ME__")
 * `cookie_samesite` (`str` - `lax`): Samesite strategy of the cookie.
 * `header_name` (`str` - `x-csrftoken`): Name of the header where you should set the CSRF token.
 * `safe_methods` (`Set[str]` - `{"GET", "HEAD", "OPTIONS", "TRACE"}`): HTTP methods considered safe which don't need CSRF protection.
+* `exempt_urls` (`Optional[List[re.Pattern]]` - `None`): List of URL regexes that the CSRF check should be skipped on. Useful if you have any APIs that you know do not need CSRF protection.
 
 ## Development
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from typing import Callable
 
 import httpx
@@ -30,6 +31,13 @@ def some_sensitive_csrfmiddleware() -> Middleware:
     return Middleware(CSRFMiddleware, secret="SECRET", sensitive_cookies={"sensitive"})
 
 
+@pytest.fixture(scope="session")
+def some_exempt_csrfmiddleware() -> Middleware:
+    return Middleware(
+        CSRFMiddleware, secret="SECRET", exempt_urls=[re.compile(r"/exempt")]
+    )
+
+
 @pytest.fixture
 def app_generator() -> Callable[[Middleware], Starlette]:
     def _app_generator(middleware: Middleware) -> Starlette:
@@ -45,6 +53,7 @@ def app_generator() -> Callable[[Middleware], Starlette]:
             routes=[
                 Route("/get", get, methods=["GET"]),
                 Route("/post", post, methods=["POST"]),
+                Route("/exempt", post, methods=["POST"]),
             ],
             middleware=[middleware],
         )
@@ -65,6 +74,14 @@ async def test_client_all_sensitive(app_generator, all_sensitive_csrfmiddleware)
 @pytest.fixture
 async def test_client_some_sensitive(app_generator, some_sensitive_csrfmiddleware):
     app = app_generator(some_sensitive_csrfmiddleware)
+    async with LifespanManager(app):
+        async with httpx.AsyncClient(app=app, base_url="http://app.io") as test_client:
+            yield test_client
+
+
+@pytest.fixture
+async def test_client_some_exempt(app_generator, some_exempt_csrfmiddleware):
+    app = app_generator(some_exempt_csrfmiddleware)
     async with LifespanManager(app):
         async with httpx.AsyncClient(app=app, base_url="http://app.io") as test_client:
             yield test_client

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -86,3 +86,25 @@ async def test_some_sensitive_csrf(test_client_some_sensitive: httpx.AsyncClient
     )
 
     assert response_post_sensitive_csrf_token.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.asyncio
+async def test_some_exempt_csrf(test_client_some_exempt: httpx.AsyncClient):
+    response_get = await test_client_some_exempt.get("/get")
+    csrf_cookie = response_get.cookies["csrftoken"]
+
+    response_post_exempt = await test_client_some_exempt.post(
+        "/exempt",
+        cookies={"foo": "bar"},
+        json={"hello": "world"},
+    )
+
+    assert response_post_exempt.status_code == status.HTTP_200_OK
+
+    response_post_not_exempt = await test_client_some_exempt.post(
+        "/post",
+        cookies={"sensitive": "bar"},
+        json={"hello": "world"},
+    )
+
+    assert response_post_not_exempt.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
This adds a new `exempt_urls` parameter which allows the user to indicate that certain URLs should be excluded from CSRF protection. It accepts a list of regular expressions, allowing for flexible exemption of nested URLs, etc.

For example, imagine you have a bunch of webhooks that you prefix with `/webhooks/`:

```
Middleware(CSRFMiddleware, secret='...', exempt_urls=[
    re.compile(r'^/webhooks/'),
]),
```

I've updated the README and added test coverage. Thanks so much for a great library! 👍 