### PR TITLE
Adds support for csrf tokens in html forms

### DIFF
--- a/starlette_csrf/middleware.py
+++ b/starlette_csrf/middleware.py
@@ -3,14 +3,12 @@ import http.cookies
 import secrets
 from re import Pattern
 from typing import Dict, List, Optional, Set, cast
-
 from itsdangerous import BadSignature
 from itsdangerous.url_safe import URLSafeSerializer
 from starlette.datastructures import URL, MutableHeaders
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
-
 
 class CSRFMiddleware:
     def __init__(
@@ -46,12 +44,13 @@ class CSRFMiddleware:
         self.header_name = header_name
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] not in ("http", "websocket"):  # pragma: no cover
+        if scope["type"] not in ("http", "websocket"):  # pragma: no cover            
             await self.app(scope, receive, send)
             return
 
-        request = Request(scope)
-        csrf_cookie = request.cookies.get(self.cookie_name)
+        request = Request(scope, receive)
+        body = await self._get_request_body(request)        
+        csrf_cookie = request.cookies.get(self.cookie_name)        
 
         if self._url_is_required(request.url) or (
             request.method not in self.safe_methods
@@ -59,6 +58,7 @@ class CSRFMiddleware:
             and self._has_sensitive_cookies(request.cookies)
         ):
             submitted_csrf_token = await self._get_submitted_csrf_token(request)
+                     
             if (
                 not csrf_cookie
                 or not submitted_csrf_token
@@ -67,9 +67,10 @@ class CSRFMiddleware:
                 response = self._get_error_response(request)
                 await response(scope, receive, send)
                 return
-
+        
+        request._receive = self._receive_with_body(request._receive, body)
         send = functools.partial(self.send, send=send, scope=scope)
-        await self.app(scope, receive, send)
+        await self.app(scope, request.receive, send)              
 
     async def send(self, message: Message, send: Send, scope: Scope) -> None:
         request = Request(scope)
@@ -89,9 +90,9 @@ class CSRFMiddleware:
             if self.cookie_domain is not None:
                 cookie[cookie_name]["domain"] = self.cookie_domain  # pragma: no cover
             headers.append("set-cookie", cookie.output(header="").strip())
-
+        
         await send(message)
-
+        
     def _has_sensitive_cookies(self, cookies: Dict[str, str]) -> bool:
         if not self.sensitive_cookies:
             return True
@@ -115,9 +116,24 @@ class CSRFMiddleware:
             if exempt_url.match(url.path):
                 return True
         return False
+    
+    async def _get_request_body(self, request: Request):
+        if request.method in ("POST", "PUT", "PATCH", "DELETE"):
+            return await request.body()
+        return b""
 
     async def _get_submitted_csrf_token(self, request: Request) -> Optional[str]:
-        return request.headers.get(self.header_name)
+        csrf_token_header = request.headers.get(self.header_name)
+        if csrf_token_header:
+            return csrf_token_header        
+        
+        csrftoken_form = await self._get_csrf_token_form(request)
+        return csrftoken_form        
+
+    async def _get_csrf_token_form(self, request: Request) -> str: 
+        form = await request.form()        
+        csrf_token = form.get(self.cookie_name, "")        
+        return csrf_token
 
     def _generate_csrf_token(self) -> str:
         return cast(str, self.serializer.dumps(secrets.token_urlsafe(128)))
@@ -125,7 +141,7 @@ class CSRFMiddleware:
     def _csrf_tokens_match(self, token1: str, token2: str) -> bool:
         try:
             decoded1: str = self.serializer.loads(token1)
-            decoded2: str = self.serializer.loads(token2)
+            decoded2: str = self.serializer.loads(token2)            
             return secrets.compare_digest(decoded1, decoded2)
         except BadSignature:
             return False
@@ -134,3 +150,8 @@ class CSRFMiddleware:
         return PlainTextResponse(
             content="CSRF token verification failed", status_code=403
         )
+    
+    def _receive_with_body(self, receive, body):
+        async def inner():
+            return {"type": "http.request", "body": body, "more_body": False}
+        return inner


### PR DESCRIPTION
**Starlette CSRF Middleware with html forms**

Added some small improvements for using CSRF tokens in HTML forms without affecting the current functionality of the middleware. The improvement simplifies the process of obtaining the CSRF token by unifying the search logic into a single function **_get_submitted_csrf_token**. Now, the function will first attempt to obtain the token from the headers, and if it does not find it there, it will search for it in the form. Additionally, this new functionality addresses the crash issue that occurs in Starlette due to body consumption.

This is particularly useful for integration with FastAPI and the development of secure websites utilizing forms. 

Now, all that's needed is to add the **starlette_csrf** middleware and utilize the following template processor in your FastAPI code: 

```py
import typing
from fastapi.templating import Jinja2Templates
from fastapi import Request
from app.core.config import settings

def csrf_token_processor(request: Request)  -> typing.Dict[str, typing.Any]:
    csrf_token = request.cookies.get(settings.CSRF_COOKIE_NAME)
    csrf_input = f'<input type="hidden" name="{settings.CSRF_COOKIE_NAME}" value="{csrf_token}">'
    csrf_header = {settings.CSRF_HEADER_NAME: csrf_token}
    return {
        'csrf_token': csrf_token,
        'csrf_input': csrf_input,
        'csrf_header': csrf_header 
        }

templates = Jinja2Templates(directory="templates", context_processors=[csrf_token_processor])
```

Simply using **{{ csrf_input | safe }}** in each form is now sufficient to ensure a more secure web application. For example:

```html
<form method="post">
    {{ csrf_input | safe }}
    <!-- Other form fields here -->
    <button type="submit">Submit</button>
</form>
```

Furthermore, we can use **{{ csrf_header }}** in HTMX requests. For example: 

```html
<form hx-patch="/route/edit" hx-headers='{{ csrf_header | tojson | safe }}'  hx-trigger="submit" hx-target="#yourtarget" hx-swap="outerHTML" >
    <!-- Other form fields here -->
    <button type="submit">Submit</button>
</form>
```
 