### PR TITLE
FIX #14 (original repo's issue)

### DIFF
--- a/starlette_csrf/middleware.py
+++ b/starlette_csrf/middleware.py
@@ -46,7 +46,7 @@ class CSRFMiddleware:
         self.header_name = header_name
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] not in ("http", "websocket"):  # pragma: no cover
+        if scope["type"] != "http":  # pragma: no cover
             await self.app(scope, receive, send)
             return
 


### PR DESCRIPTION
Thanks to [@gantoine](https://github.com/gantoine) with its good workaround,
it was simple to write a fix for issue #14 

The exempt_urls method is not enough because it prevents checking csrf token, 
but it does not prevent sending the "wrong" scope with type = "http", triggering the assert in requests.

(Useful code is in `middleware.py`, lines starting from 56.

I locally tested it.

